### PR TITLE
Don't use nodegit-papandreou.

### DIFF
--- a/lib/GitFakeFs.js
+++ b/lib/GitFakeFs.js
@@ -1,7 +1,7 @@
 var Path = require('path'),
     util = require('util'),
     async = require('async'),
-    nodeGit = require('nodegit-papandreou'),
+    nodeGit = require('nodegit'),
     _ = require('underscore'),
     passError = require('passerror'),
     memoizeAsync = require('memoizeasync'),

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "createerror": "=0.4.1",
     "memoizeasync": "=0.3.1",
     "ncp": "=0.4.2",
-    "nodegit-papandreou": "=0.1.0patch3",
+    "nodegit": "=0.1.4",
     "passerror": "0.0.2",
     "underscore": "=1.5.2"
   }

--- a/test/GitIndexEntry.js
+++ b/test/GitIndexEntry.js
@@ -3,7 +3,7 @@ var expect = require('unexpected'),
     Path = require('path'),
     fs = require('fs'),
     GitIndexEntry = require('../lib/GitIndexEntry'),
-    nodeGit = require('nodegit-papandreou');
+    nodeGit = require('nodegit');
 
 describe('GitIndexEntry', function () {
     var pathToTestRepo = Path.resolve(__dirname, 'testRepo.git');


### PR DESCRIPTION
Slint doesn't build, because nodegit-papandreou can't properly build libgit2 properly.

Stock nodegit can (and seem to incorporate all requests from papandreou), so I've tried using that.

It does, however, still fail a single unit-test (I strongly suspect git/libgit knowledge will make it easier to debug).
